### PR TITLE
Add crate-specific toolchain pin

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This is a small adjustment, but it allows people who default to Stable, but have Nightly installed, to not make changes to run the test.